### PR TITLE
Make Current Location Icon more prominent.

### DIFF
--- a/src/Maps/LocationSelectorMap.js
+++ b/src/Maps/LocationSelectorMap.js
@@ -59,7 +59,7 @@ class Map extends Component {
         onDragEnd={this.onDragEnd}
       >
         {this.props.geoLocation ?
-          <Marker position={this.props.geoLocation} icon={dotIcon} />
+          <Marker zIndex={100} position={this.props.geoLocation} icon={dotIcon} />
           : null}
         {this.state.markerPosition ?
           <Marker


### PR DESCRIPTION
Fixes https://github.com/covid-maps/covid-maps/issues/238

The current location will be the most prominent thing now.