### PR TITLE
Prevent Reload on SW update.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,6 @@ serviceWorker.register({
     if (registration && registration.waiting) {
       registration.waiting.postMessage({ type: 'SKIP_WAITING' });
     }
-    window.location.reload();
+    // window.location.reload();
   }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,5 @@ serviceWorker.register({
     if (registration && registration.waiting) {
       registration.waiting.postMessage({ type: 'SKIP_WAITING' });
     }
-    // window.location.reload();
   }
 });


### PR DESCRIPTION
Should Fix https://github.com/covid-maps/covid-maps/issues/214 for the moment.

But Ideally would want a better scenario, maybe one where we can mark a release to forcefully reload as a part of big release.